### PR TITLE
Add player blips and locomotive visibility settings

### DIFF
--- a/RemoteDispatch/Data/CarData.cs
+++ b/RemoteDispatch/Data/CarData.cs
@@ -53,10 +53,10 @@ namespace DvMod.RemoteDispatch
             );
         }
 
-        public static JObject GetAllCarDataJson()
+        public static JObject GetAllCarDataJson(bool withLocomotives)
         {
             return JObject.FromObject(
-                GetAllCarData().ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToJson()));
+                GetAllCarData(withLocomotives).ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToJson()));
         }
 
         public static JObject? GetCarGuidDataJson(string guid)
@@ -64,7 +64,7 @@ namespace DvMod.RemoteDispatch
             var (carId, carData) = Updater.RunOnMainThread(() =>
             {
                 var car = TrainCarRegistry.Instance.GetTrainCarByCarGuid(guid);
-                if (car == null || !ShouldReturnTrainCar(car))
+                if (car == null || !ShouldReturnTrainCar(car, true))
                     return default;
                 return (car.ID, From(car));
             }).Result;
@@ -75,14 +75,14 @@ namespace DvMod.RemoteDispatch
             return obj;
         }
 
-        public static Dictionary<string, CarData> GetAllCarData()
+        public static Dictionary<string, CarData> GetAllCarData(bool? withLocomotives)
         {
             return Updater.RunOnMainThread(() =>
             {
                 return TrainCarRegistry.Instance
                     .logicCarToTrainCar
                     .Values
-                    .Where(ShouldReturnTrainCar)
+                    .Where(car => ShouldReturnTrainCar(car, withLocomotives))
                     .ToDictionary(car => car.ID, car => From(car));
             }).Result;
         }
@@ -95,7 +95,7 @@ namespace DvMod.RemoteDispatch
                 if (trainset == null)
                     return new Dictionary<string, JObject>();
                 return trainset.cars
-                    .Where(ShouldReturnTrainCar)
+                    .Where(car => ShouldReturnTrainCar(car, true))
                     .ToDictionary(car => car.ID, car => From(car).ToJson());
             }).Result;
         }
@@ -105,8 +105,9 @@ namespace DvMod.RemoteDispatch
             return JObject.FromObject(GetTrainsetData(id));
         }
 
-        public static bool ShouldReturnTrainCar(TrainCar trainCar)
+        public static bool ShouldReturnTrainCar(TrainCar trainCar, bool? withLocomotives)
         {
+            if(!(withLocomotives ?? false) && trainCar.IsLoco) return false;
             if (Main.settings.showUndiscoveredLocomotives)
                 return true;
             var state = LocoRestorationController.GetForTrainCar(trainCar)?.State;

--- a/RemoteDispatch/Engine/CarUpdater.cs
+++ b/RemoteDispatch/Engine/CarUpdater.cs
@@ -44,7 +44,7 @@ namespace DvMod.RemoteDispatch
 
         public static void MarkTrainsetAsDirty(Trainset trainset)
         {
-            if (trainset.cars.Find(CarData.ShouldReturnTrainCar) != null)
+            if (trainset.cars.Find(car => CarData.ShouldReturnTrainCar(car, true)) != null)
                 Sessions.AddTag($"trainset-{trainset.id}");
         }
 

--- a/RemoteDispatch/Main.cs
+++ b/RemoteDispatch/Main.cs
@@ -43,6 +43,7 @@ namespace DvMod.RemoteDispatch
         private static void OnSaveGUI(UnityModManager.ModEntry modEntry)
         {
             settings.Save(modEntry);
+            Sessions.AddTag("cars");
         }
 
         private static bool OnToggle(UnityModManager.ModEntry modEntry, bool value)

--- a/RemoteDispatch/Server/HttpServer.cs
+++ b/RemoteDispatch/Server/HttpServer.cs
@@ -115,6 +115,11 @@ namespace DvMod.RemoteDispatch
 #if DEBUG
                 Main.mod?.Logger.Log("/player endpoint hit");
 #endif
+                if(!Main.settings.permissions.CanSeePlayerBlips(context.User.Identity.Name))
+                {
+                    RenderEmpty(context, 200);
+                    break;
+                }
                 var playerJson = PlayerData.GetPlayerDataJson();
                 if (playerJson != null)
                     Render200(context, ContentTypes.Json, playerJson);
@@ -165,7 +170,7 @@ namespace DvMod.RemoteDispatch
             var segments = context.Request.Url.Segments;
             if (segments.Length == 2 && context.Request.HttpMethod == "GET")
             {
-                var allCarDataJson = CarData.GetAllCarDataJson();
+                var allCarDataJson = CarData.GetAllCarDataJson(Main.settings.permissions.CanSeeLocomotives(context.User.Identity.Name));
                 Render200(context, allCarDataJson);
                 return;
             }

--- a/RemoteDispatch/Server/Session.cs
+++ b/RemoteDispatch/Server/Session.cs
@@ -13,7 +13,7 @@ namespace DvMod.RemoteDispatch
         private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(5);
         private static readonly object allSesssionsLock = new object();
         private static readonly Dictionary<string, Session> allSessions = new Dictionary<string, Session>();
-        private static readonly HashSet<string> AllTags = new HashSet<string>() { "cars", "jobs", "junctions", "player" };
+        private static readonly HashSet<string> BaseTags = new HashSet<string>() { "cars", "jobs", "junctions", "player" };
 
         public static event Action<string>? OnSessionStarted;
         public static event Action<string>? OnSessionEnded;
@@ -27,8 +27,40 @@ namespace DvMod.RemoteDispatch
             public Session(string username)
             {
                 this.username = username;
-                foreach (var tag in AllTags)
+                foreach (var tag in BaseTags)
+                {
+                    AddTagIfPermitted(tag);
+                }
+            }
+
+            public void AddTagIfPermitted(string tag)
+            {
+                if (username == null) return;
+                switch (tag)
+                {
+                case "cars":
+                    if (Main.settings.permissions.CanSeeLocomotives(username))
+                    {
+                        pendingTags.Add("carsWithLocomotives");
+                    }
+                    else
+                    {
+                        pendingTags.Add("cars");
+                    }
+                    break;
+                case "player":
+                    if (Main.settings.permissions.CanSeePlayerBlips(username))
+                    {
+                        pendingTags.Add("player");
+                    } else
+                    {
+                        pendingTags.Add("playerNull");
+                    }
+                    break;
+                default:
                     pendingTags.Add(tag);
+                    break;
+                }
             }
         }
 
@@ -36,6 +68,7 @@ namespace DvMod.RemoteDispatch
         {
             return new HashSet<string>(allSessions.Values.Select(s => s.username));
         }
+
 
         public static void AddTag(string tag)
         {
@@ -49,7 +82,7 @@ namespace DvMod.RemoteDispatch
                     if (session.timeSinceLastFetch.Elapsed > SessionTimeout)
                         timedOutSessions.Add(sessionId);
                     else
-                        session.pendingTags.Add(tag);
+                        session.AddTagIfPermitted(tag);
                 }
                 foreach (var sessionId in timedOutSessions)
                 {
@@ -112,19 +145,31 @@ namespace DvMod.RemoteDispatch
         {
             return tag switch
             {
-                "cars" => JObject.FromObject(CarData.GetAllCarData().ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToJson())),
+                "cars" => JObject.FromObject(CarData.GetAllCarData(false).ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToJson())),
+                "carsWithLocomotives" => JObject.FromObject(CarData.GetAllCarData(true).ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToJson())),
                 "jobs" => JObject.FromObject(JobData.GetAllJobData()),
                 "junctions" => new JArray(Junctions.GetAllJunctionStates()),
                 "player" => PlayerData.GetPlayerData(),
+                "playerNull" => new JObject(),
                 _ when tag.Contains('-') => GetUpdateForSplitTag(tag),
                 _ => throw new NotImplementedException($"Unexpected update tag {tag}"),
+            };
+        }
+
+        private static string GetFrontendTagName(string tag)
+        {
+            return tag switch
+            {
+                "carsWithLocomotives" => "cars",
+                "playerNull" => "player",
+                _ => tag
             };
         }
 
         public static async Task<string> GetUpdates(string username, string sessionId)
         {
             var tags = await GetTags(username, sessionId).ConfigureAwait(false);
-            return JsonConvert.SerializeObject(tags.ToDictionary(tag => tag, tag => GetUpdateForTag(tag)));
+            return JsonConvert.SerializeObject(tags.ToDictionary(tag => GetFrontendTagName(tag), tag => GetUpdateForTag(tag)));
         }
     }
 }

--- a/RemoteDispatch/Settings.cs
+++ b/RemoteDispatch/Settings.cs
@@ -70,6 +70,8 @@ namespace DvMod.RemoteDispatch
             public string name;
             public bool canToggleJunctions;
             public bool canControlLocomotives;
+            public bool canSeePlayerBlips;
+            public bool canSeeLocomotives;
 
             public PlayerPermissions()
             {
@@ -98,6 +100,14 @@ namespace DvMod.RemoteDispatch
         {
             return permissions.Find(p => p.name == username)?.canControlLocomotives ?? false;
         }
+        public bool CanSeePlayerBlips(string username)
+        {
+            return permissions.Find(p => p.name == username)?.canSeePlayerBlips ?? false;
+        }
+        public bool CanSeeLocomotives(string username)
+        {
+            return permissions.Find(p => p.name == username)?.canSeeLocomotives ?? false;
+        }
 
         private void OnSessionStarted(string username)
         {
@@ -116,6 +126,8 @@ namespace DvMod.RemoteDispatch
             DrawConnectedColumn();
             DrawJunctionsColumn();
             DrawLocoControlColumn();
+            DrawPlayerBlipsColumn();
+            DrawSeeLocomotivesColumn();
             GUILayout.EndHorizontal();
         }
 
@@ -147,6 +159,14 @@ namespace DvMod.RemoteDispatch
         private void DrawLocoControlColumn()
         {
             DrawColumn("Locomotive Control", p => p.canControlLocomotives = GUILayout.Toggle(p.canControlLocomotives, ""));
+        }
+        private void DrawPlayerBlipsColumn()
+        {
+            DrawColumn("Player Blips", p => p.canSeePlayerBlips = GUILayout.Toggle(p.canSeePlayerBlips, ""));
+        }
+        private void DrawSeeLocomotivesColumn()
+        {
+            DrawColumn("Locomotive Visibility", p => p.canSeeLocomotives = GUILayout.Toggle(p.canSeeLocomotives, ""));
         }
     }
 }


### PR DESCRIPTION
Add two new per-player configurable settings - Player Blips and Locomotive Visibility.

When Player Blips is disabled, users will not see players on the map, regardless of their frontend settings. If Player Blips is enabled, they can still choose to disable them on the frontend.

When Locomotive Vibility is disabled, locomotives will not show up on the map. Cars will still show up - this means that players could still keep track of a train's location by looking at the ways cars are moving, but they can't use player blips or highlighted locomotives to know where trains are.

To implement these features, I've created the following new methods:

`Sessions.GetFrontendTagName` - to facilitate the new permissions, I've created two new tags - `carsWithLocomotives` and `playerNull`. These are functional equivalents to the existing `cars` and `player` tags, but the information from them is gathered differently. In order for the frontend to have the frontend recognize these tags as if they're the standard unmodified versions, GetFrontendTagName(tag) returns the "standard" name for the given tag.

`Session.AddTagIfPermitted` - Adds a tag to the list of pending session tags only if the user has the correct permissions for that tag. If the user does not have permissions, the tag can be skipped or another tag can be substituited. This could help with implementing future permissions. 
