### PR TITLE
Add configurable default permissions for new users

### DIFF
--- a/RemoteDispatch/Server/Session.cs
+++ b/RemoteDispatch/Server/Session.cs
@@ -52,7 +52,8 @@ namespace DvMod.RemoteDispatch
                     if (Main.settings.permissions.CanSeePlayerBlips(username))
                     {
                         pendingTags.Add("player");
-                    } else
+                    }
+                    else
                     {
                         pendingTags.Add("playerNull");
                     }
@@ -101,9 +102,9 @@ namespace DvMod.RemoteDispatch
                 if (!allSessions.TryGetValue(sessionId, out session))
                 {
                     Main.Log($"Starting new session {sessionId} for user {username}");
+                    OnSessionStarted?.Invoke(username);
                     session = new Session(username);
                     allSessions.Add(sessionId, session);
-                    OnSessionStarted?.Invoke(username);
                 }
             }
 

--- a/RemoteDispatch/Settings.cs
+++ b/RemoteDispatch/Settings.cs
@@ -85,9 +85,21 @@ namespace DvMod.RemoteDispatch
             {
                 this.name = name;
             }
+
+            public PlayerPermissions ShallowCopy()
+            {
+                return (PlayerPermissions)MemberwiseClone();
+            }
         }
 
         public readonly List<PlayerPermissions> permissions = new List<PlayerPermissions>();
+        public PlayerPermissions defaultPermissions = new PlayerPermissions{
+            name = "Default",
+            canToggleJunctions =  true,
+            canControlLocomotives = true,
+            canSeePlayerBlips = true,
+            canSeeLocomotives = true
+        };
 
         public Permissions()
         {
@@ -116,7 +128,10 @@ namespace DvMod.RemoteDispatch
         {
             if (!permissions.Any(p => p.name == username))
             {
-                permissions.Add(new PlayerPermissions(username));
+                var clonedPermissions = defaultPermissions.ShallowCopy();
+                clonedPermissions.name = username;
+
+                permissions.Add(clonedPermissions);
                 permissions.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.name, b.name));
             }
         }
@@ -138,6 +153,7 @@ namespace DvMod.RemoteDispatch
         {
             GUILayout.BeginVertical();
             GUILayout.Label(label);
+            action(defaultPermissions);
             foreach (var p in permissions)
                 action(p);
             GUILayout.EndVertical();


### PR DESCRIPTION
Adds the ability to configure the permissions that will be given to new users. Users who have already logged in and have permissions saved in the settings are not impacted.

This is accomplished by saving a new PlayerPermissions object and cloning that object when initializing permissions for new users.

In Session.cs, `OnSessionStarted.?Invoke(username)` is moved above the session initialization, so that the session is only initialized once the default permissions for the user have been applied - with the original order, the initial load would happen with all permissions set to false, instead of the correct default permissions.